### PR TITLE
quick gcc 10 workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ configure: build
 	--with-ld-opt="-lm -latomic $(MEM_LD_FLAGS)" \
 	$(MODULE_ARG)=$(CURDIR)/51Degrees_module \
 	--with-compat \
-	--with-cc-opt="$(ARGS) $(MEM_CC_FLAGS)" \
+	--with-cc-opt="$(ARGS) $(MEM_CC_FLAGS) -fcommon" \
 	--with-debug \
 	--sbin-path=$(CURDIR) \
 	--conf-path="nginx.conf" \


### PR DESCRIPTION
GCC 10 now defaults to -fno-common which breaks compilation: https://gcc.gnu.org/gcc-10/porting_to.html