### PR TITLE
Fix missing libatomic linking when building using config file (#7)

### DIFF
--- a/module_conf/hash_config
+++ b/module_conf/hash_config
@@ -1,12 +1,27 @@
+ngx_feature="51Degrees detection"
+ngx_feature_name=
+ngx_feature_run=no
+ngx_feature_incs=
+ngx_feature_libs=-latomic
+ngx_feature_test="__atomic_compare_exchange_16"
+. auto/feature
+
 ngx_addon_name=ngx_http_51D_module
 
-if test -n "$ngx_module_link"; then
-	ngx_module_type=HTTP
-	ngx_module_name=ngx_http_51D_module
-	ngx_module_srcs="$ngx_addon_dir/ngx_http_51D_module.c $ngx_addon_dir/src/*.c $ngx_addon_dir/src/hash/*.c $ngx_addon_dir/src/common-cxx/*.c"
-
-	. auto/module
+if [ $ngx_found = yes ]; then
+	if test -n "$ngx_module_link"; then
+		ngx_module_type=HTTP
+		ngx_module_name=ngx_http_51D_module
+		ngx_module_srcs="$ngx_addon_dir/ngx_http_51D_module.c $ngx_addon_dir/src/*.c $ngx_addon_dir/src/hash/*.c $ngx_addon_dir/src/common-cxx/*.c"
+	    ngx_module_libs="$ngx_feature_libs"
+		. auto/module
+	else
+		HTTP_MODULES="$HTTP_MODULES ngx_http_51D_module"
+		NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_51D_module.c $ngx_addon_dir/src/*.c $ngx_addon_dir/src/hash/*.c $ngx_addon_dir/src/common-cxx/*.c"
+	fi
 else
-	HTTP_MODULES="$HTTP_MODULES ngx_http_51D_module"
-	NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_51D_module.c $ngx_addon_dir/src/*.c $ngx_addon_dir/src/hash/*.c $ngx_addon_dir/src/common-cxx/*.c"
+	cat << END
+$0: error: the 51Degrees module requires the libatomic library.
+END
+	exit 1
 fi


### PR DESCRIPTION
I've always been building the nginx module using the included `config` file, and encountered the libatomic linking issues mentioned in #7 which could be worked around on x86 using the `-mcx16` gcc flag, but not on arm where that flag isn't supported.

I've updated the `config` file to have it properly check for `__atomic_compare_exchange_16` as well as link against `libatomic`. When the library isn't present, the configure script now properly errors out with the following:
```
----------------------------------------
checking for 51Degrees detection

objs/autotest.c: In function 'main':
objs/autotest.c:7:5: warning: statement with no effect [-Wunused-value]
     __atomic_compare_exchange_16;
     ^
/usr/bin/ld: cannot find /usr/lib64/libatomic.so.1.0.0
collect2: error: ld returned 1 exit status
----------

#include <sys/types.h>
#include <unistd.h>


int main(void) {
    __atomic_compare_exchange_16;
    return 0;
}

----------
cc -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -std=gnu11 -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -o objs/autotest objs/autotest.c -Wl,-z,relro -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -Wl,-E -latomic
----------
```

And when present, it builds and now gets properly linked to libatomic:
```
$ ldd /usr/lib64/nginx/modules/ngx_http_51D_module.so
	linux-vdso.so.1 =>  (0x00007ffc716f8000)
	libatomic.so.1 => /lib64/libatomic.so.1 (0x00007fb92aea8000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fb92aada000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fb92a8be000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fb92b2d3000)
```