### PR TITLE
FIX removed extra single-quote from test evidence

### DIFF
--- a/tests/51degrees.t
+++ b/tests/51degrees.t
@@ -299,12 +299,12 @@ HEAD $uri HTTP/1.1
 Host: localhost
 Connection: close
 user-agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Mobile Safari/537.36
-sec-ch-ua-platform: '"Android"'
-sec-ch-ua-model: '"SM-S918B"'
+sec-ch-ua-platform: "Android"
+sec-ch-ua-model: "SM-S918B"
 sec-ch-ua-mobile: ?1
-sec-ch-ua-platform-version: '"13.0"'
-sec-ch-ua-full-version-list: '"Google Chrome";v="117.0.5938.60", "Not;A=Brand";v="8.0.0.0", "Chromium";v="117.0.5938.60"'
-sec-ch-ua: '"Google Chrome";v="117", "Not;A=Brand";v="8", "Chromium";v="117"'
+sec-ch-ua-platform-version: "13.0.0"
+sec-ch-ua-full-version-list: "Google Chrome";v="117.0.5938.60", "Not;A=Brand";v="8.0.0.0", "Chromium";v="117.0.5938.60"
+sec-ch-ua: "Google Chrome";v="117", "Not;A=Brand";v="8", "Chromium";v="117"
 
 EOF
 }


### PR DESCRIPTION
fixing 2 [failing tests](https://github.com/51Degrees/device-detection-nginx/actions/runs/8593558385/job/23545242566#step:5:1809) PlatformVersion was not retrieved due to misformated evidence