### PR TITLE
tests: update minimum CMake version

### DIFF
--- a/tests/performance/CMakeLists.txt
+++ b/tests/performance/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.24)
 project(PerformanceTest)
 
 include(ExternalProject)


### PR DESCRIPTION
Newer CMake dropped compatibility with CMake <3.5, so we update the version to the one used in common-cxx.