### PR TITLE
Support aligned 51DEGREES_DD_PATH and 51DEGREES_IPI_PATH data file environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,16 @@ endif
 MODULEPATH := $(FULLPATH)/build/modules/ngx_http_51D_module.so
 FILEPATH := $(FULLPATH)/device-detection-cxx/device-detection-data/$(DATAFILE)
 
+# The aligned environment variable 51DEGREES_DD_PATH provides an explicit
+# path to a device detection data file and is checked first. The legacy
+# FIFTYONEDEGREES_DATAFILE name variable above is retained for backwards
+# compatibility and is combined with the expected data folder when no
+# explicit path is provided.
+ifdef 51DEGREES_DD_PATH
+	FILEPATH := $(51DEGREES_DD_PATH)
+	DATAFILE := $(notdir $(51DEGREES_DD_PATH))
+endif
+
 
 ifndef STATIC_BUILD
 	MODULE_ARG := --add-dynamic-module

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ FULLPATH := $(shell pwd)
 ifndef FIFTYONEDEGREES_DATAFILE
 	DATAFILE := 51Degrees-LiteV4.1.hash
 else
+$(warning FIFTYONEDEGREES_DATAFILE is deprecated and will be removed in a future release. Use 51DEGREES_DD_PATH with an explicit path to the data file instead.)
 	DATAFILE := $(FIFTYONEDEGREES_DATAFILE)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ endif
 ifndef FIFTYONEDEGREES_DATAFILE_IPI
 	DATAFILE_IPI := 51Degrees-IPIV4AsnIpiV41.ipi
 else
+$(warning FIFTYONEDEGREES_DATAFILE_IPI is deprecated and will be removed in a future release. Use 51DEGREES_IPI_PATH with an explicit path to the data file instead.)
 	DATAFILE_IPI := $(FIFTYONEDEGREES_DATAFILE_IPI)
 endif
 
@@ -47,6 +48,13 @@ FILEPATH_IPI := $(FULLPATH)/ip-intelligence-cxx/ip-intelligence-data/$(DATAFILE_
 ifdef 51DEGREES_DD_PATH
 	FILEPATH := $(51DEGREES_DD_PATH)
 	DATAFILE := $(notdir $(51DEGREES_DD_PATH))
+endif
+
+# The aligned environment variable 51DEGREES_IPI_PATH provides an explicit
+# path to an IP intelligence data file in the same way.
+ifdef 51DEGREES_IPI_PATH
+	FILEPATH_IPI := $(51DEGREES_IPI_PATH)
+	DATAFILE_IPI := $(notdir $(51DEGREES_IPI_PATH))
 endif
 
 

--- a/README.md
+++ b/README.md
@@ -314,9 +314,9 @@ make test 51DEGREES_DD_PATH=/path/to/51Degrees-EnterpriseV4.1.hash
 Note that when running Nginx itself the data file is always specified
 explicitly with the `51D_file_path` directive in the configuration file.
 
-The IP intelligence tests use the data file specified by the `FIFTYONEDEGREES_DATAFILE_IPI` variable, defaulting to the `51Degrees-IPIV4AsnIpiV41.ipi` file included in the sub-module. The file should be placed in the `ip-intelligence-cxx/ip-intelligence-data` folder. The IP intelligence example tests are skipped when the file is not present. e.g.
+The IP intelligence tests resolve their data file in the same order. The `51DEGREES_IPI_PATH` environment variable provides an explicit path to the file. The legacy `FIFTYONEDEGREES_DATAFILE_IPI` variable provides a file name that is combined with the `ip-intelligence-cxx/ip-intelligence-data` folder, it is deprecated and using it prints a make warning. When neither variable is set the `51Degrees-IPIV4AsnIpiV41.ipi` file included in the sub-module is used. The IP intelligence example tests are skipped when the file is not present. e.g.
 ```
-make test-examples FIFTYONEDEGREES_DATAFILE_IPI=51Degrees-IPIV4AsnIpiV41.ipi
+make test-examples 51DEGREES_IPI_PATH=/path/to/51Degrees-IPIV4AsnIpiV41.ipi
 ```
 
 ## Performance Test
@@ -376,7 +376,7 @@ Before running the tests for the example, make sure to obtain data files that co
 
 Run the example tests with the obtained data files:
 ```
-make test-examples 51DEGREES_DD_PATH=[Path to obtained data file] FIFTYONEDEGREES_DATAFILE_IPI=[Obtained IP intelligence data file]
+make test-examples 51DEGREES_DD_PATH=[Path to obtained data file] 51DEGREES_IPI_PATH=[Path to obtained IP intelligence data file]
 ```
 
 ### Javascript and overrides example test

--- a/README.md
+++ b/README.md
@@ -228,9 +228,9 @@ To run the 51Degrees together with the Nginx test suite, run the following comma
 make test-full
 ```
 
-These do not run all the required tests as some tests requires properties that are not supported with the Lite version of the data file. To run all tests, obtain a data file with support properties JavascriptHardwareProfile,ScreenPixelsWidthJavascript and ScreenPixelsWidth. Then, use the `FIFTYONEDEGREES_DATAFILE` variable to specify the file name to run the tests with. The new data file should be placed in the `device-detection-cxx\device-detection-data` folder and should have different name to `51Degrees-LiteV4.1.hash`. If tests still fail, obtain data file with any other properties used in the tests. Below is an example of running tests with different data file:
+These do not run all the required tests as some tests requires properties that are not supported with the Lite version of the data file. To run all tests, obtain a data file with support properties JavascriptHardwareProfile,ScreenPixelsWidthJavascript and ScreenPixelsWidth. Then, use the `51DEGREES_DD_PATH` variable to specify the path of the data file to run the tests with. If tests still fail, obtain data file with any other properties used in the tests. Below is an example of running tests with different data file:
 ```
-make [test|test-full] FIFTYONEDEGREES_DATAFILE=51Degrees-EnterpriseV4.1.hash
+make [test|test-full] 51DEGREES_DD_PATH=/path/to/51Degrees-EnterpriseV4.1.hash
 ```
 
 The data file used by the tests is resolved in the following order:
@@ -239,7 +239,8 @@ The data file used by the tests is resolved in the following order:
    path to the data file.
 2. The legacy `FIFTYONEDEGREES_DATAFILE` variable, which provides a file name
    that is combined with the `device-detection-cxx/device-detection-data`
-   folder.
+   folder. This variable is deprecated and will be removed in a future
+   release. Using it prints a make warning, use `51DEGREES_DD_PATH` instead.
 3. When neither variable is set, the free Lite data file
    `51Degrees-LiteV4.1.hash` in the `device-detection-cxx/device-detection-data`
    folder is used.
@@ -303,7 +304,7 @@ Before running the tests for the example, make sure to obtain a data file that c
 
 Run the example tests with the obtained data file:
 ```
-make test-examples FIFTYONEDEGREES_DATAFILE=[Obtained data file]
+make test-examples 51DEGREES_DD_PATH=[Path to obtained data file]
 ```
 
 ### Javascript and overrides example test

--- a/README.md
+++ b/README.md
@@ -233,6 +233,25 @@ These do not run all the required tests as some tests requires properties that a
 make [test|test-full] FIFTYONEDEGREES_DATAFILE=51Degrees-EnterpriseV4.1.hash
 ```
 
+The data file used by the tests is resolved in the following order:
+
+1. The `51DEGREES_DD_PATH` environment variable, which provides an explicit
+   path to the data file.
+2. The legacy `FIFTYONEDEGREES_DATAFILE` variable, which provides a file name
+   that is combined with the `device-detection-cxx/device-detection-data`
+   folder.
+3. When neither variable is set, the free Lite data file
+   `51Degrees-LiteV4.1.hash` in the `device-detection-cxx/device-detection-data`
+   folder is used.
+
+For example:
+```
+make test 51DEGREES_DD_PATH=/path/to/51Degrees-EnterpriseV4.1.hash
+```
+
+Note that when running Nginx itself the data file is always specified
+explicitly with the `51D_file_path` directive in the configuration file.
+
 ## Performance Test
 
 The project also include a performance test suite. This required `CMake 10` or above to be installed.


### PR DESCRIPTION
## Summary

This change aligns the data file environment variable used by the test Makefile with the convention shared across 51Degrees repositories.

- `51DEGREES_DD_PATH` provides an explicit path to the device detection data file and is checked first. The legacy `FIFTYONEDEGREES_DATAFILE` name variable is retained and is combined with the expected data folder when no explicit path is provided. The free Lite data file in device-detection-cxx/device-detection-data remains the default.
- The README documents the resolution order.

## Notes

- When running Nginx itself the data file is always specified explicitly with the `51D_file_path` directive, which is unchanged.
- The aligned name starts with a digit, which POSIX shells do not accept in plain assignments. Pass it as a make argument, for example `make test 51DEGREES_DD_PATH=/path/to/file.hash`, or use the env command.
