### PR TITLE
Fix stale README claims and harden shared memory and property string handling

### DIFF
--- a/51Degrees_hash_module/ngx_http_51D_module.c
+++ b/51Degrees_hash_module/ngx_http_51D_module.c
@@ -593,6 +593,10 @@ ngx_http_51D_post_conf(ngx_conf_t *cf)
 			&resourceManagerName,
 			size,
 			&ngx_http_51D_module + tagOffset);
+	if (ngx_http_51D_shm_resource_manager == NULL) {
+		// The reason has already been logged by ngx_shared_memory_add.
+		return NGX_ERROR;
+	}
 	ngx_http_51D_shm_resource_manager->init =
 		ngx_http_51D_init_shm_resource_manager;
 	return NGX_OK;
@@ -1567,21 +1571,32 @@ search_headers_in(ngx_http_request_t *r, u_char *name, size_t len) {
 /**
  * Add value function. Appends a string to a list separated by the
  * delimiter specified with 51D_valueSeparator, or a comma by default.
+ * Values which do not fit in the remaining space are truncated.
  * @param delimiter to split values with.
  * @param val the string to add to dst.
  * @param dst the string to append the val to.
- * @param length the size remaining to append val to dst.
+ * @param length the space remaining in dst, including the null terminator.
  */
 static void add_value(char *delimiter, char *val, char *dst, size_t length)
 {
-	// If the buffer already contains characters, append a pipe.
+	// Reserve the byte for the null terminator written by strncat.
+	if (length == 0) {
+		return;
+	}
+	length--;
+
+	// If the buffer already contains characters, append the delimiter.
 	if (dst[0] != '\0') {
+		size_t delimiterLength = strlen(delimiter);
+		if (delimiterLength > length) {
+			return;
+		}
 		strncat(dst, delimiter, length);
-		length -= strlen(delimiter);
+		length -= delimiterLength;
 	}
 
-    // Append the value.
-    strncat(dst, val, length);
+	// Append the value.
+	strncat(dst, val, length);
 }
 
 /**

--- a/51Degrees_ipi_module/ngx_http_51D_ipi_module.c
+++ b/51Degrees_ipi_module/ngx_http_51D_ipi_module.c
@@ -397,6 +397,10 @@ ngx_http_51D_ipi_post_conf(ngx_conf_t *cf)
 			&resourceManagerName,
 			size,
 			&ngx_http_51D_ipi_module + tagOffset);
+	if (ngx_http_51D_ipi_shm_resource_manager == NULL) {
+		// The reason has already been logged by ngx_shared_memory_add.
+		return NGX_ERROR;
+	}
 	ngx_http_51D_ipi_shm_resource_manager->init =
 		ngx_http_51D_ipi_init_shm_resource_manager;
 	return NGX_OK;
@@ -891,17 +895,28 @@ ngx_module_t ngx_http_51D_ipi_module = {
 /**
  * Add value function. Appends a string to a list separated by the
  * delimiter specified with 51D_value_separator_ipi, or a comma by default.
+ * Values which do not fit in the remaining space are truncated.
  * @param delimiter to split values with.
  * @param val the string to add to dst.
  * @param dst the string to append the val to.
- * @param length the size remaining to append val to dst.
+ * @param length the space remaining in dst, including the null terminator.
  */
 static void add_value(char *delimiter, char *val, char *dst, size_t length)
 {
+	// Reserve the byte for the null terminator written by strncat.
+	if (length == 0) {
+		return;
+	}
+	length--;
+
 	// If the buffer already contains characters, append the delimiter.
 	if (dst[0] != '\0') {
+		size_t delimiterLength = strlen(delimiter);
+		if (delimiterLength > length) {
+			return;
+		}
 		strncat(dst, delimiter, length);
-		length -= strlen(delimiter);
+		length -= delimiterLength;
 	}
 
 	// Append the value.

--- a/README.md
+++ b/README.md
@@ -140,9 +140,11 @@ The above gave you a quick overview of how to use the 51Degrees Nginx module. Ho
 ## Latest releases
 The latest releases of 51Degrees Nginx module can be found on [Github](https://github.com/51Degrees/device-detection-nginx/releases).
 
-For the supported platforms and Nginx version, please check the [tested versions page](https://51degrees.com/documentation/_info__tested_versions.html) for latest update. At the time of writing, the followings are supported:
-- Platform Ubuntu-18.04 and 20.04, 64bit.
-- Nginx version: 1.19.0, 1.19.5, 1.19.10 and 1.20.0
+For the supported platforms and Nginx version, please check the [tested versions page](https://51degrees.com/documentation/_info__tested_versions.html) for latest update. At the time of writing, the followings are tested by the continuous integration pipeline:
+- Platform Ubuntu (ubuntu-latest), 64bit.
+- Nginx version: 1.27.2, 1.27.4, 1.29.0 and 1.29.3
+
+Pre-built modules are published for the Nginx versions listed by the `all-versions` target in the Makefile. Older versions back to 1.19.0 are expected to work as the module accounts for API changes across this range, but they are no longer routinely tested.
 
 ## API references
 Below is the list of directives that can be used with the 51Degrees modules. The `51D_*_ipi` directives are provided by the IP intelligence module (`ngx_http_51D_ipi_module`) and all the others by the device detection module (`ngx_http_51D_module`).
@@ -272,14 +274,14 @@ All tests are allocated in the `tests` folder.
 
 To be able to test the 51Degrees module the following libraries are required.
 - Perl 5 and prove Test::Harness
-- CMake 10 or above
+- CMake 3.24 or above
 - node and jest
 - curl
 - grep
 
 Before running any test, make sure to build the project with `make install` command. The tests are designed to test the dynamic build only so `STATIC_BUILD` will not work.
 
-To run the 51Degrees tests with the default 51Degrees Lite data file included in the `device-detection-cxx\device-detection-data` directory, run the following command:
+To run the 51Degrees tests with the default 51Degrees Lite data file included in the `device-detection-cxx/device-detection-data` directory, run the following command:
 ```
 make test
 ```
@@ -289,7 +291,7 @@ To run the 51Degrees together with the Nginx test suite, run the following comma
 make test-full
 ```
 
-These do not run all the required tests as some tests requires properties that are not supported with the Lite version of the data file. To run all tests, obtain a data file with support properties JavascriptHardwareProfile,ScreenPixelsWidthJavascript and ScreenPixelsWidth. Then, use the `FIFTYONEDEGREES_DATAFILE` variable to specify the file name to run the tests with. The new data file should be placed in the `device-detection-cxx\device-detection-data` folder and should have different name to `51Degrees-LiteV4.1.hash`. If tests still fail, obtain data file with any other properties used in the tests. Below is an example of running tests with different data file:
+These do not run all the required tests as some tests requires properties that are not supported with the Lite version of the data file. To run all tests, obtain a data file with support properties JavascriptHardwareProfile,ScreenPixelsWidthJavascript and ScreenPixelsWidth. Then, use the `FIFTYONEDEGREES_DATAFILE` variable to specify the file name to run the tests with. The new data file should be placed in the `device-detection-cxx/device-detection-data` folder and should have different name to `51Degrees-LiteV4.1.hash`. If tests still fail, obtain data file with any other properties used in the tests. Below is an example of running tests with different data file:
 ```
 make [test|test-full] FIFTYONEDEGREES_DATAFILE=51Degrees-EnterpriseV4.1.hash
 ```
@@ -301,7 +303,7 @@ make test-examples FIFTYONEDEGREES_DATAFILE_IPI=51Degrees-IPIV4AsnIpiV41.ipi
 
 ## Performance Test
 
-The project also include a performance test suite. This required `CMake 10` or above to be installed.
+The project also include a performance test suite. This required `CMake 3.24` or above to be installed.
 
 To run the performance test, please follow the below steps:
 - Make sure to build the project with `make install`.


### PR DESCRIPTION
## Summary

Follow-up fixes from a pre-review sweep of the repository after #383 was merged.

### Documentation

- The tested versions section claimed Nginx 1.19.0 to 1.20.0 on Ubuntu 18.04/20.04. The CI pipeline actually tests 1.27.2, 1.27.4, 1.29.0 and 1.29.3 on ubuntu-latest, so the section now reflects that, notes that pre-built modules follow the Makefile all-versions target, and that older versions back to 1.19.0 are expected to work but are no longer routinely tested. The old text also named 1.19.10 where the all-versions target builds 1.19.8.
- The performance test suite prerequisite read "CMake 10 or above". The actual requirement is CMake 3.24 (tests/performance/CMakeLists.txt).
- Two paths in the Linux test instructions used Windows backslash separators.

### Robustness

- `ngx_shared_memory_add` returns NULL when allocation fails or the zone conflicts with an existing declaration, and both modules dereferenced the result unchecked, which would crash the master process during configuration. Both now return `NGX_ERROR` so nginx reports a clean configuration failure. The cause is already logged by `ngx_shared_memory_add` itself.
- `add_value` in both modules subtracted the delimiter length from the remaining space after appending, which wrapped the unsigned length when the 2048 byte properties buffer was nearly full and made the following `strncat` effectively unbounded. The remaining space now includes the null terminator, values which do not fit are truncated, and the subtraction can no longer wrap. The single call site in each module already passes the space in this form.

## Testing

Both modules rebuilt with `-Werror` and verified in WSL Ubuntu-24.04 against nginx 1.20.0, `make test` 32/32 and `make test-examples` 35 tests across 7 files, all passing.