### PR TITLE
Package and install both modules in the publish pipeline

### DIFF
--- a/ci/build-package-requirements.ps1
+++ b/ci/build-package-requirements.ps1
@@ -5,10 +5,9 @@ param(
     [string]$NginxVersion
 )
 
-$ModuleName = "ngx_http_51D_module.so"
+$ModuleNames = @("ngx_http_51D_module.so", "ngx_http_51D_ipi_module.so")
 $RepoPath = [IO.Path]::Combine($pwd, $RepoName)
 $OutputDir = [IO.Path]::Combine($pwd, "package-files")
-$OutputFile = [IO.Path]::Combine($OutputDir, $ModuleName)
 
 Write-Output "Entering '$RepoPath'"
 Push-Location $RepoPath
@@ -21,10 +20,12 @@ try {
     # as artifacts.
     New-Item -Path $OutputDir -ItemType Directory -Force 
     
-    $InputFile = [IO.Path]::Combine($RepoPath, "build", "modules", $ModuleName)
-
-    # Copy module
-    Copy-Item -Path $InputFile -Destination $OutputFile
+    # Copy both the device detection and IP intelligence modules
+    foreach ($ModuleName in $ModuleNames) {
+        $InputFile = [IO.Path]::Combine($RepoPath, "build", "modules", $ModuleName)
+        $OutputFile = [IO.Path]::Combine($OutputDir, $ModuleName)
+        Copy-Item -Path $InputFile -Destination $OutputFile
+    }
 
 }
 finally {

--- a/ci/install-package.ps1
+++ b/ci/install-package.ps1
@@ -9,14 +9,13 @@ param(
 # Combine the current working directory with the repository name
 $RepoPath = [IO.Path]::Combine($pwd, $RepoName)
 
-$ModuleName = "ngx_http_51D_module.so"
+$ModuleNames = @("ngx_http_51D_module.so", "ngx_http_51D_ipi_module.so")
 
 # Define the path for downloaded artifacts
-$PackagePath = [IO.Path]::Combine($pwd, "package", "package_$Name", $ModuleName)
+$PackageDir = [IO.Path]::Combine($pwd, "package", "package_$Name")
 
 # Get the local install path
 $ModulesPath = [IO.Path]::Combine($RepoPath, "build", "modules")
-$InstallPath = [IO.Path]::Combine($ModulesPath, $ModuleName)
 
 # Display the repository path and enter it
 Write-Output "Entering '$RepoPath'"
@@ -30,10 +29,14 @@ try {
         Write-Output "Install NGINX '$NginxVersion' without 51Degrees module"
         make install-no-module FIFTYONEDEGREES_NGINX_VERSION=$NginxVersion
 
-        # Now copy the module to the installs module directory
-        Write-Output "Copying the 51Degrees module from '$PackagePath' to '$InstallPath'"
+        # Now copy both modules to the installs module directory
         mkdir $ModulesPath
-        Copy-Item -Path $PackagePath -Destination $InstallPath
+        foreach ($ModuleName in $ModuleNames) {
+            $PackagePath = [IO.Path]::Combine($PackageDir, $ModuleName)
+            $InstallPath = [IO.Path]::Combine($ModulesPath, $ModuleName)
+            Write-Output "Copying the 51Degrees module from '$PackagePath' to '$InstallPath'"
+            Copy-Item -Path $PackagePath -Destination $InstallPath
+        }
 
     }
     else {


### PR DESCRIPTION
## Problem

The Nightly Pipeline run on main failed this morning (run 27392194547) in all four Nightly Publish test jobs. The example tests could not start nginx because `build/modules/ngx_http_51D_ipi_module.so` did not exist, failing at dlopen.

## Cause

The publish flow stages module binaries with `ci/build-package-requirements.ps1` and the test jobs install them with `ci/install-package.ps1`. Both scripts hardcoded the single `ngx_http_51D_module.so` name, so the IP intelligence module added in #383 was never packaged or installed. The pull request pipeline builds the project directly with `make install`, which produces both modules, which is why PR CI stayed green.

## Change

Both scripts now iterate over the two module names, staging and installing the device detection and IP intelligence binaries. Explicit names are kept rather than a wildcard so a missing module fails the pipeline loudly instead of silently publishing a partial package.

The remaining single-module reference in `ci/run-unit-tests.ps1` is the NGINX Plus globals for the upstream nginx-tests suite, which only needs the hash module, and is intentionally unchanged.