### PR TITLE
Wait longer for nginx to start when loading a full IP intelligence file

### DIFF
--- a/tests/examples/ipiGettingStarted.t
+++ b/tests/examples/ipiGettingStarted.t
@@ -19,11 +19,34 @@ BEGIN { use FindBin; chdir($FindBin::Bin); }
 use lib '../nginx-tests/lib';
 use Test::Nginx;
 use URI::Escape;
+use POSIX qw/ WNOHANG /;
 
 ###############################################################################
 
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
+
+# A full IP intelligence data file is loaded into shared memory before the
+# master process writes its pid file, which can take tens of seconds. The
+# five second wait in Test::Nginx::waitforfile is too short for that, so
+# extend it to two minutes. The loop still returns as soon as the pid file
+# appears, so small data files are unaffected.
+{
+	no warnings 'redefine';
+	*Test::Nginx::waitforfile = sub {
+		my ($self, $file, $pid) = @_;
+		my $exited;
+
+		for (1 .. 1200) {
+			return 1 if -e $file;
+			return 0 if $exited;
+			$exited = waitpid($pid, WNOHANG) != 0 if $pid;
+			select undef, undef, undef, 0.1;
+		}
+
+		return undef;
+	};
+}
 
 sub read_example($) {
 	my ($name) = @_;

--- a/tests/examples/mixedGettingStarted.t
+++ b/tests/examples/mixedGettingStarted.t
@@ -20,11 +20,34 @@ BEGIN { use FindBin; chdir($FindBin::Bin); }
 use lib '../nginx-tests/lib';
 use Test::Nginx;
 use URI::Escape;
+use POSIX qw/ WNOHANG /;
 
 ###############################################################################
 
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
+
+# A full IP intelligence data file is loaded into shared memory before the
+# master process writes its pid file, which can take tens of seconds. The
+# five second wait in Test::Nginx::waitforfile is too short for that, so
+# extend it to two minutes. The loop still returns as soon as the pid file
+# appears, so small data files are unaffected.
+{
+	no warnings 'redefine';
+	*Test::Nginx::waitforfile = sub {
+		my ($self, $file, $pid) = @_;
+		my $exited;
+
+		for (1 .. 1200) {
+			return 1 if -e $file;
+			return 0 if $exited;
+			$exited = waitpid($pid, WNOHANG) != 0 if $pid;
+			select undef, undef, undef, 0.1;
+		}
+
+		return undef;
+	};
+}
 
 sub read_example($) {
 	my ($name) = @_;


### PR DESCRIPTION
## Problem

Running `make test-examples` with a production IP intelligence data file (multiple gigabytes) fails in `ipiGettingStarted.t` and `mixedGettingStarted.t` with "Can't start nginx". The module copies the data file into the shared memory zone during master process init, before the pid file is written. With a 5.8 GB Enterprise file this takes about 30 seconds, while `Test::Nginx::waitforfile` gives up after a hardcoded 5 seconds, removes the test directory and fails the test while nginx is still starting.

## Change

The two tests which load an IP intelligence file override `waitforfile` after loading `Test::Nginx`, keeping the original logic but extending the wait to two minutes. The loop returns as soon as the pid file appears, so runs with the small bundled data files (including CI, which uses the Asn file) are unaffected.

## Verification

- `make test-examples` with the bundled files passes 35/35 in 6 seconds, unchanged.
- `make test-examples 51DEGREES_DD_PATH=<Enterprise hash> 51DEGREES_IPI_PATH=<Enterprise ipi>` previously failed both tests, now passes 35/35.