### PR TITLE
Publish performance graphs under stable version-free names

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -18,6 +18,7 @@ The following secrets are required to run the full set of tests agains NGINX Plu
 - There are no packages produced by this repository, so the only output from the `Nightly Publish Main` workflow is a new tag and release.
 - The package update step does not update dependencies from a package manager in the same way as other repos. Instead it checks the supported versions on the [NGINX Plus Releases](https://docs.nginx.com/nginx/releases/) page, and uses that to update `options.json` to ensure they are tested.
 - As Windows is not supported, the scripts here can be a little less strict with implementation. e.g. using `cp` rather than `Copy-Item` as we know we're in a Linux environment.
+- The performance test configurations in `options.json` use stable names with no NGINX version, `ubuntu-latest` for device detection and `ubuntu-latest_IPI` for IP intelligence. The performance graphs published to the gh-images branch are named after the configuration, and the graph URLs are referenced from the documentation, so the names must not change between version updates. The `_IPI` configuration exists so that a separate IP intelligence graph is published. Its results file is produced by the main configuration in the publish flow, see `run-performance-tests.ps1`.
 
 ### Build Options
 

--- a/ci/options.json
+++ b/ci/options.json
@@ -1,7 +1,7 @@
 [
   {
     "Image": "ubuntu-latest",
-    "Name": "ubuntu-latest_Nginx1.29.3",
+    "Name": "ubuntu-latest",
     "NginxVersion": "1.29.3",
     "NginxPlusVersion": "36",
     "RunPerformance": true,
@@ -13,6 +13,12 @@
     "Name": "ubuntu-latest_Nginx1.29.3_MemCheck",
     "NginxVersion": "1.29.3",
     "MemCheck": true
+  },
+  {
+    "Image": "ubuntu-latest",
+    "Name": "ubuntu-latest_IPI",
+    "NginxVersion": "1.29.3",
+    "RunPerformance": true
   },
   {
     "Image": "ubuntu-latest",

--- a/ci/run-performance-tests.ps1
+++ b/ci/run-performance-tests.ps1
@@ -9,6 +9,29 @@ $PSNativeCommandUseErrorActionPreference = $true
 $repo = (Get-Item $PSScriptRoot/..).FullName
 $summary = New-Item -ItemType directory -Force -Path $repo/test-results/performance-summary
 
+# Write the results of the last runPerf.sh run for comparison under the
+# given configuration name.
+function Write-Results {
+    param([Parameter(Mandatory)][string]$ResultsName)
+    $results = Get-Content -Raw ./summary.json | ConvertFrom-Json
+    @{
+        HigherIsBetter = @{
+            DetectionsPerSecond = 1/($results.overhead_ms / 1000)
+        }
+        LowerIsBetter = @{
+            AvgMillisecsPerDetection = $results.overhead_ms
+        }
+    } | ConvertTo-Json > $summary/results_$ResultsName.json
+}
+
+# The IP intelligence results are published under the _IPI suffixed
+# configuration name so that they get their own performance graph. The
+# main configuration produces the results for both names, as the publish
+# flow only runs the performance tests for the main configuration. When
+# this script runs for the dedicated _IPI configuration, in the pull
+# request flow, only the IP intelligence test is run.
+$ipiOnly = $Name -like '*_IPI'
+
 $build = New-Item -ItemType directory -Force -Path "$repo/tests/performance/build"
 Push-Location $build
 try {
@@ -17,59 +40,45 @@ try {
     cmake ..
     cmake --build .
 
-    # When running the performance tests, set the data file name manually,
-    # then unset once we're done
-    Write-Host "Running device detection performance test"
-    $env:DATA_FILE_NAME="TAC-HashV41.hash"
-    ./runPerf.sh
-    $env:DATA_FILE_NAME=$Null
+    if (-not $ipiOnly) {
+        # When running the performance tests, set the data file name manually,
+        # then unset once we're done
+        Write-Host "Running device detection performance test"
+        $env:DATA_FILE_NAME="TAC-HashV41.hash"
+        ./runPerf.sh
+        $env:DATA_FILE_NAME=$Null
 
-    # Write out the results for comparison
-    Write-Host "Writing device detection performance test results"
-    $results = Get-Content -Raw ./summary.json | ConvertFrom-Json
-    @{
-        HigherIsBetter = @{
-            DetectionsPerSecond = 1/($results.overhead_ms / 1000)
-        }
-        LowerIsBetter = @{
-            AvgMillisecsPerDetection = $results.overhead_ms
-        }
-    } | ConvertTo-Json > $summary/results_$Name.json
+        Write-Host "Writing device detection performance test results"
+        Write-Results $Name
+    }
 
-    # Run the performance test again for the IP intelligence module using
-    # the Asn data file included in the ip-intelligence-data sub-module.
+    # Run the performance test for the IP intelligence module using the
+    # Asn data file included in the ip-intelligence-data sub-module.
     Write-Host "Running IP intelligence performance test"
     $env:ENGINE="ipi"
     ./runPerf.sh
     $env:ENGINE=$Null
 
-    # Write out the results for comparison
     Write-Host "Writing IP intelligence performance test results"
-    $results = Get-Content -Raw ./summary.json | ConvertFrom-Json
-    @{
-        HigherIsBetter = @{
-            DetectionsPerSecond = 1/($results.overhead_ms / 1000)
-        }
-        LowerIsBetter = @{
-            AvgMillisecsPerDetection = $results.overhead_ms
-        }
-    } | ConvertTo-Json > $summary/results_$($Name)_IPI.json
+    Write-Results ($ipiOnly ? $Name : "$($Name)_IPI")
 } finally {
     Pop-Location
 }
 
 
-Push-Location $repo
-try {
-    # Run the stress test script. ApacheBench will already be built from the previous test
-    Write-Host "Run stress tests using ApacheBench"
-    if (Test-Path -Path "tests/performance/build/ApacheBench-prefix/src/ApacheBench-build/bin/ab") {
-        $env:DATA_FILE_NAME="TAC-HashV41.hash"
-        ./test.sh
-        $env:DATA_FILE_NAME=$Null
-    } else {
-        Write-Error 'The performance test need to be build first.'
+if (-not $ipiOnly) {
+    Push-Location $repo
+    try {
+        # Run the stress test script. ApacheBench will already be built from the previous test
+        Write-Host "Run stress tests using ApacheBench"
+        if (Test-Path -Path "tests/performance/build/ApacheBench-prefix/src/ApacheBench-build/bin/ab") {
+            $env:DATA_FILE_NAME="TAC-HashV41.hash"
+            ./test.sh
+            $env:DATA_FILE_NAME=$Null
+        } else {
+            Write-Error 'The performance test need to be build first.'
+        }
+    } finally {
+        Pop-Location
     }
-} finally {
-    Pop-Location
 }

--- a/ci/update-packages.ps1
+++ b/ci/update-packages.ps1
@@ -36,7 +36,12 @@ foreach ($release in $supportedReleases) {
     foreach ($image in $Images) {
         [void]$options.Add([ordered]@{
             Image = $image
-            Name = "$($image)_Nginx$($openSourceOf[$release])"
+            # The latest version's configuration runs the performance tests
+            # and is named after the image alone, with no NGINX version. The
+            # performance graphs published to the gh-images branch are named
+            # after the configuration, and a stable name keeps the published
+            # graph URLs working across version updates.
+            Name = $isLatest ? $image : "$($image)_Nginx$($openSourceOf[$release])"
             NginxVersion = $openSourceOf[$release]
             NginxPlusVersion = $release
             RunPerformance = $IsLatest # Only run performance if this is the latest NGINX Plus version
@@ -50,6 +55,17 @@ foreach ($release in $supportedReleases) {
                 Name = "$($image)_Nginx$($openSourceOf[$release])_MemCheck"
                 NginxVersion = $openSourceOf[$release]
                 MemCheck = $True
+            })
+            # The IP intelligence performance graph is published under this
+            # separate configuration name. The results file for it is
+            # produced by the main configuration above, see
+            # ci/run-performance-tests.ps1, so this configuration has no
+            # PackageRequirement and the publish flow skips its jobs.
+            [void]$options.Add([ordered]@{
+                Image = $image
+                Name = "$($image)_IPI"
+                NginxVersion = $openSourceOf[$release]
+                RunPerformance = $True
             })
             # # TODO: uncomment when static build works
             # [void]$options.Add([ordered]@{


### PR DESCRIPTION
## Problem

Two issues with the performance graphs feeding the benchmarks page:

1. The graph published to gh-images is named after the latest version's options entry (`perf-graph-ubuntu-latest_Nginx1.29.3-DetectionsPerSecond-latest.png`), so every NGINX version update changes the file name and would break the URL referenced from the documentation benchmarks page.
2. The IP intelligence results file (`results_<Name>_IPI.json`) written by `run-performance-tests.ps1` was never published as a graph. The common-ci comparison step only reads results files named after an options entry, so the file was silently ignored.

## Change

Follows the convention used by the other repositories, where each published graph corresponds to a stably named configuration:

- The latest version's configuration is now named after the image alone (`ubuntu-latest`), with the NGINX version still recorded in its `NginxVersion` field. Graph becomes `perf-graph-ubuntu-latest-DetectionsPerSecond-latest.png`.
- A new `ubuntu-latest_IPI` configuration publishes the IP intelligence graph (`perf-graph-ubuntu-latest_IPI-DetectionsPerSecond-latest.png`). It has no `PackageRequirement`, so the publish flow skips its jobs, and its results file is produced by the main configuration's performance run, which the comparison step picks up from the merged artifacts. In the pull request flow it runs only the IP intelligence performance test, so its results carry real measurements there too.
- `options.json` is regenerated with the modified `update-packages.ps1`, so the nightly package update reproduces it exactly.
- `ci/README.md` documents the naming constraint.

## Notes

- The packages produced per entry are internal to the pipeline (`publish-package.ps1` publishes nothing), and no branch protection rules reference job names, so the rename is safe.
- Graph history restarts under the new names. There was only one day of history.
- The gh-images branch is recreated as an orphan on each publish, so the old versioned graph disappears automatically.