### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 51Degrees Real-Time Data Nginx Module
 
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_campaign=nginx_open_source&utm_content=readme_main "Data rewards the curious") **Real-Time Data in C** Nginx module
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-nginx&utm_content=readme.md&utm_term=51degrees-real-time-data-nginx-module "Data rewards the curious") **Real-Time Data in C** Nginx module
 
-[Developer documentation](https://51degrees.com/documentation/_other_integrations__nginx.html)
+[Developer documentation](https://51degrees.com/documentation/_other_integrations__nginx.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-nginx&utm_content=readme.md&utm_term=51degrees-real-time-data-nginx-module)
 
 # Introduction 
 This project integrates the 51Degrees real-time data engines as modules to Nginx, allowing users to configure Nginx to enrich requests with real-time data by setting corresponding 51Degrees directives in the Nginx configuration file. Two engines are available, the Device Detection V4 engine which provides device properties from request headers, and the IP Intelligence engine which provides network and location properties from the client IP address. Each engine is built as its own dynamic module (`ngx_http_51D_module` for device detection and `ngx_http_51D_ipi_module` for IP intelligence) and the modules can be loaded together or independently. Currently only Linux platform is supported.
@@ -19,7 +19,7 @@ In order to use the module, you will need at least one 51Degrees data file. Each
 This repository includes a free, 'lite' file in the 'device-detection-data' 
 sub-module that has a significantly reduced set of properties. To obtain a 
 file with a more complete set of device properties see the 
-[51Degrees website](https://51degrees.com/pricing). 
+[51Degrees website](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-nginx&utm_content=readme.md&utm_term=device-detection-data-file). 
 If you want to use the lite file, you will need to install [GitLFS](https://git-lfs.github.com/).
 
 For Linux:
@@ -38,7 +38,7 @@ git lfs pull
 
 The 'ip-intelligence-data' sub-module includes a free `51Degrees-IPIV4AsnIpiV41.ipi` file which contains the Asn properties (Asn and AsnName). This file is used by default for the IP intelligence examples and tests.
 
-The sub-module also provides scripts (`get-lite-file-from-azure.sh`) to download a free, 'lite' IP intelligence data file which has a different, reduced set of properties (RegisteredCountry, RegisteredName and RegisteredOwner). Note that the version of the downloaded data file must match the version expected by the ip-intelligence-cxx sub-module, as with any 51Degrees data file. To obtain a file with the complete set of properties see the [51Degrees website](https://51degrees.com/pricing).
+The sub-module also provides scripts (`get-lite-file-from-azure.sh`) to download a free, 'lite' IP intelligence data file which has a different, reduced set of properties (RegisteredCountry, RegisteredName and RegisteredOwner). Note that the version of the downloaded data file must match the version expected by the ip-intelligence-cxx sub-module, as with any 51Degrees data file. To obtain a file with the complete set of properties see the [51Degrees website](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-nginx&utm_content=readme.md&utm_term=ip-intelligence-data-file).
 
 ## Quick Start (Device Detection)
 
@@ -140,7 +140,7 @@ The above gave you a quick overview of how to use the 51Degrees Nginx module. Ho
 ## Latest releases
 The latest releases of 51Degrees Nginx module can be found on [Github](https://github.com/51Degrees/device-detection-nginx/releases).
 
-For the supported platforms and Nginx version, please check the [tested versions page](https://51degrees.com/documentation/_info__tested_versions.html) for latest update. At the time of writing, the followings are tested by the continuous integration pipeline:
+For the supported platforms and Nginx version, please check the [tested versions page](https://51degrees.com/documentation/_info__tested_versions.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-nginx&utm_content=readme.md&utm_term=latest-releases) for latest update. At the time of writing, the followings are tested by the continuous integration pipeline:
 - Platform Ubuntu (ubuntu-latest), 64bit.
 - Nginx version: 1.27.2, 1.27.4, 1.29.0 and 1.29.3
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -7,7 +7,7 @@ The following secrets are required:
     * Example: `github_pat_l0ng_r4nd0m_s7r1ng`
   
 The following secrets are required to run tests:
-* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing) for downloading assets (TAC hashes file and TAC CSV data file)
+* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-nginx&utm_content=ci-readme.md&utm_term=api-specific-ci-approach) for downloading assets (TAC hashes file and TAC CSV data file)
     * Example: `V3RYL0NGR4ND0M57R1NG`
 
 The following secrets are required to run the full set of tests agains NGINX Plus:

--- a/examples/hash/jsExample/javascript.conf
+++ b/examples/hash/jsExample/javascript.conf
@@ -9,7 +9,7 @@ in full on [GitHub](https://github.com/51Degrees/device-detection-nginx/blob/mas
 
 Properties required for this example are not included in the free Lite file,
 so a data file that includes ScreenPixelsWidth and ScreenPixelsWidthJavascript
-need to be obtained from [configurator](https://configure.51degrees.com/).
+need to be obtained from [configurator](https://configure.51degrees.com/?utm_source=code&utm_medium=example&utm_campaign=device-detection-nginx&utm_content=examples-hash-jsexample-javascript.conf&utm_term=top).
 
 Before using the example, update the followings:
 - Remove this 'how to' guide block.


### PR DESCRIPTION
## Summary

Every navigational 51degrees.com and configure.51degrees.com link in this repository now carries the standard UTM query string so the Content Team can trace Matomo campaign traffic to the exact repository, file, and location it came from:

`?utm_source=<github|code|nuget|npm|maven|packagist>&utm_medium=<readme|docs|example|comment|package>&utm_campaign=<repository>&utm_content=<file slug>&utm_term=<location in file>`

7 links across 4 files, in-place URL replacements only, re-applied against the restructured README from the IP intelligence merge. The old utm_campaign=nginx_open_source scheme on the logo was replaced and the new IP intelligence sections' links tagged. Functional endpoints, test fixtures, license headers, and generated files are untouched.

## Lint

A second commit adds the utm-link-lint workflow, which runs the shared script from 51Degrees/common-ci on pull requests and pushes to main, keeping the convention enforced from now on. The lint check on this PR stays red until 51Degrees/common-ci#207 merges, since the workflow fetches the script from that repository's main.

The full convention is documented in UTM-LINK-TAGGING.md in 51Degrees/internal-common-ci (PR 3).