### PR TITLE
Benchmark with default engine matching options

### DIFF
--- a/tests/performance/nginx.conf.template
+++ b/tests/performance/nginx.conf.template
@@ -13,8 +13,6 @@ http {
     51D_file_path ${DATA_FILE_DIR}/51Degrees-LiteV4.1.hash;
 
 	51D_value_separator ^sep^;
-	51D_drift 1;
-	51D_difference 1;
 	51D_allow_unmatched on;
 
     server {


### PR DESCRIPTION
## Problem

The performance test template enables `51D_drift 1` and `51D_difference 1`, carried over unchanged from the original V4 implementation commit where they exercised those engine code paths. Both options widen the hash search whenever a node fails to match exactly, so the published benchmark pays a penalty on every request that no default production configuration would pay. The device-detection-cxx benchmark the graphs sit alongside on the benchmarks page runs with neither option.

Measured on a controlled rig (single worker, in-memory content, Enterprise data file, the 20,000 User-Agent workload), removing them reduces the `51D_match_all` per-request overhead by roughly a quarter at the current baseline.

## Change

Remove the two directives from [tests/performance/nginx.conf.template](https://github.com/51Degrees/device-detection-nginx/blob/main/tests/performance/nginx.conf.template). `51D_value_separator` and `51D_allow_unmatched` are kept, they do not affect match cost.

## Notes

This is the first of the fixes from the performance investigation. The dominant cost, the engine being initialised with all properties instead of the ones named in the directives, is a module code fix and will follow separately.