### PR TITLE
Run the performance benchmark across multiple concurrent requests

### DIFF
--- a/tests/performance/nginx.conf.ipi.template
+++ b/tests/performance/nginx.conf.ipi.template
@@ -1,4 +1,4 @@
-worker_processes 4;
+worker_processes auto;
 
 load_module ${MODULES_DIR}/ngx_http_51D_ipi_module.so;
 

--- a/tests/performance/nginx.conf.template
+++ b/tests/performance/nginx.conf.template
@@ -1,4 +1,4 @@
-worker_processes 4;
+worker_processes auto;
 
 load_module ${MODULES_DIR}/ngx_http_51D_module.so;
 

--- a/tests/performance/runPerf.sh
+++ b/tests/performance/runPerf.sh
@@ -2,11 +2,27 @@
 
 # Constants
 FULLPATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
-PASSES=20000
 HOST=127.0.0.1:3000
 CAL=calibrate
 PRO=process
 PERF=./ApacheBench-prefix/src/ApacheBench-build/bin/runPerf.sh
+
+# Run the benchmark with as many concurrent requests as there are
+# processors, matching the worker_processes auto setting in the config
+# templates, so that all of the Nginx workers are exercised at once. This
+# mirrors the multi threaded benchmarks of the other 51Degrees APIs rather
+# than measuring a single request at a time. Override with CONCURRENCY.
+CONCURRENCY=${CONCURRENCY:-$(nproc)}
+
+# Number of requests per worker. The total passed to ApacheBench scales
+# with the concurrency so that each phase runs for the same wall-clock
+# time however many processors the machine has. The overhead is measured
+# as the difference between the calibration and processing wall times, so
+# holding that time constant keeps the measurement resolution constant
+# and stops the difference from disappearing into timing noise on a
+# machine with many cores.
+PASSES_PER_WORKER=${PASSES_PER_WORKER:-20000}
+PASSES=$((PASSES_PER_WORKER * CONCURRENCY))
 
 # The engine to test. Either 'hash' (device detection, the default) or
 # 'ipi' (IP intelligence).
@@ -63,7 +79,7 @@ mv $REPO_DIR/build/nginx.conf $REPO_DIR/build/nginx.conf.bkp
 cp $FULLPATH/nginx.conf $REPO_DIR/build/nginx.conf
 
 # Run the performrance
-$PERF -n $PASSES -s "$REPO_DIR/nginx" -t "$REPO_DIR/nginx -s stop" -c $CAL -p $PRO -h $HOST
+$PERF -n $PASSES -s "$REPO_DIR/nginx" -t "$REPO_DIR/nginx -s stop" -c $CAL -p $PRO -h $HOST -k $CONCURRENCY
 
 # Replace the original config
 mv $REPO_DIR/build/nginx.conf.bkp $REPO_DIR/build/nginx.conf


### PR DESCRIPTION
## Summary

The Nginx performance benchmark drove the service one request at a time (ApacheBench's default concurrency of 1), so only a single worker was ever busy and the published [benchmarks page](https://github.com/51Degrees/documentation) figure measured single-threaded throughput. Every other 51Degrees API benchmarks across all hardware threads, so the Nginx figure was the odd one out and not comparable.

## Change

- `worker_processes auto` in both performance config templates, so Nginx runs one worker per processor.
- The wrapper drives ApacheBench with concurrency equal to the processor count (`nproc`), via the new `-k` concurrency argument added to the shared apachebench `runPerf` harness.
- The number of passes scales with the concurrency, so each phase runs for the same wall-clock time regardless of core count. This keeps the resolution of the calibrate-vs-process overhead measurement constant rather than letting the difference shrink into timing noise as cores rise (which would risk a meaningless negative overhead on a many-core runner).

## Dependency

Requires [apachebench#15](https://github.com/51Degrees/apachebench/pull/15) (merged), which adds the `-k`/`--concurrency` argument to `runPerf.sh`/`runPerf.ps1`. The harness is fetched at build time, so this takes effect on the next performance build.

## Verification

- apachebench harness change verified: ApacheBench reports the requested `Concurrency Level` and throughput scales (2,630 req/s at 1, 5,912 req/s at 4, 0 failures).
- End-to-end overhead measurement at concurrency 4 (matching a 4-core CI runner) is robustly positive across repeated runs (0.010-0.021 ms overhead, ~50-100k detections/sec aggregate), versus ~22,500/s single-threaded. The published figure will rise to reflect multi-threaded throughput, comparable to the other APIs.

The authoritative number will come from the next nightly on clean CI hardware.