### PR TITLE
Benchmark device detection with the shared evidence records

### DIFF
--- a/tests/performance/CMakeLists.txt
+++ b/tests/performance/CMakeLists.txt
@@ -58,6 +58,41 @@ if(NOT UAS_TARGET_OK)
     endif()
 endif()
 
+# Obtain the evidence records file in the same way. This is the same set
+# of evidence the other 51Degrees APIs benchmark against, so the device
+# detection benchmark sends a full set of headers per request (including
+# the Sec-CH-UA client hints) rather than a User-Agent alone. The file is
+# copied to a name without spaces so it is simple to pass on a command
+# line.
+set(EVIDENCE_LOCAL
+    "${CMAKE_CURRENT_LIST_DIR}/../../device-detection-cxx/device-detection-data/20000 Evidence Records.yml")
+set(EVIDENCE_TARGET ${CMAKE_BINARY_DIR}/evidence.yml)
+set(EVIDENCE_MIN_SIZE 1000000)
+
+check_file_size(${EVIDENCE_TARGET} ${EVIDENCE_MIN_SIZE} EVIDENCE_TARGET_OK)
+if(NOT EVIDENCE_TARGET_OK)
+    check_file_size(${EVIDENCE_LOCAL} ${EVIDENCE_MIN_SIZE} EVIDENCE_LOCAL_OK)
+    if(EVIDENCE_LOCAL_OK)
+        message(STATUS "Using evidence file from device-detection-data")
+        file(COPY_FILE ${EVIDENCE_LOCAL} ${EVIDENCE_TARGET})
+    else()
+        message(STATUS "Downloading evidence file")
+        file(DOWNLOAD
+            https://media.githubusercontent.com/media/51Degrees/device-detection-data/master/20000%20Evidence%20Records.yml
+            ${EVIDENCE_TARGET}
+            TIMEOUT 120  # seconds
+            TLS_VERIFY ON)
+        check_file_size(${EVIDENCE_TARGET} ${EVIDENCE_MIN_SIZE} EVIDENCE_DOWNLOAD_OK)
+        if(NOT EVIDENCE_DOWNLOAD_OK)
+            message(WARNING
+                "The evidence file could not be obtained from the "
+                "device-detection-data sub-module (use 'git lfs pull') or "
+                "downloaded. The device detection benchmark will fall back "
+                "to varied User-Agents only.")
+        endif()
+    endif()
+endif()
+
 add_custom_target(perf ALL
     COMMAND cp ${CMAKE_CURRENT_LIST_DIR}/runPerf.sh .
 	COMMAND cp ${CMAKE_CURRENT_LIST_DIR}/nginx.conf.template .

--- a/tests/performance/runPerf.sh
+++ b/tests/performance/runPerf.sh
@@ -28,6 +28,11 @@ PASSES=$((PASSES_PER_WORKER * CONCURRENCY))
 # 'ipi' (IP intelligence).
 ENGINE=${ENGINE:-hash}
 
+# Evidence file passed to the benchmark. Empty by default, which leaves the
+# harness rotating the User-Agents file. Set for the device detection
+# engine below when an evidence file is available.
+EVIDENCE=
+
 # Get the repo directory as an absolute path
 ORIGINPATH="$(pwd)"
 cd $FULLPATH/../../../
@@ -65,6 +70,12 @@ else
 	if [ -f uas.csv.bkp ]; then
 		mv uas.csv.bkp uas.csv
 	fi
+	# Send the full evidence records, matching the other 51Degrees API
+	# benchmarks, when the evidence file is available. Otherwise fall back
+	# to the User-Agents file the harness uses by default.
+	if [ -f "$FULLPATH/evidence.yml" ]; then
+		EVIDENCE="$FULLPATH/evidence.yml"
+	fi
 fi
 
 # Create required directories and target files for service
@@ -79,7 +90,11 @@ mv $REPO_DIR/build/nginx.conf $REPO_DIR/build/nginx.conf.bkp
 cp $FULLPATH/nginx.conf $REPO_DIR/build/nginx.conf
 
 # Run the performrance
-$PERF -n $PASSES -s "$REPO_DIR/nginx" -t "$REPO_DIR/nginx -s stop" -c $CAL -p $PRO -h $HOST -k $CONCURRENCY
+if [ -n "$EVIDENCE" ]; then
+	$PERF -n $PASSES -s "$REPO_DIR/nginx" -t "$REPO_DIR/nginx -s stop" -c $CAL -p $PRO -h $HOST -k $CONCURRENCY -E "$EVIDENCE"
+else
+	$PERF -n $PASSES -s "$REPO_DIR/nginx" -t "$REPO_DIR/nginx -s stop" -c $CAL -p $PRO -h $HOST -k $CONCURRENCY
+fi
 
 # Replace the original config
 mv $REPO_DIR/build/nginx.conf.bkp $REPO_DIR/build/nginx.conf


### PR DESCRIPTION
## Summary

The device detection benchmark drove ApacheBench with the User-Agents file (`20000 User Agents.csv`), so it matched on a single User-Agent header per request. The other 51Degrees API benchmarks (cxx, .NET, Java, …) run against the full evidence records (`20000 Evidence Records.yml`), which also carry the `Sec-CH-UA` client hint headers. The Nginx figure therefore measured a lighter workload than the rest and was not directly comparable, even though it already used the same data file (`TAC-HashV41.hash`).

## Change

- The perf CMake obtains `20000 Evidence Records.yml` the same way as the User-Agents file (sub-module copy preferred, download fallback, size check against an LFS pointer), copying it to `evidence.yml`.
- The wrapper passes it to the benchmark via the `-E` evidence option for the device detection engine, so each request now sends a full record of headers. It falls back to User-Agents if the evidence file cannot be obtained.
- The IP intelligence benchmark is unchanged (it sends IP addresses).

## Dependency

Requires [apachebench#16](https://github.com/51Degrees/apachebench/pull/16) (merged), which adds the `-E`/`--evidence` option to `ab` and the `runPerf` scripts. The harness is fetched at build time, so this takes effect on the next performance build.

## Verification

- `ab -E` with the real `20000 Evidence Records.yml` loads 19,999 records and runs 2,000 requests with 0 failures against an Nginx doing `51D_match_all`; raw-request capture confirms a multi-header record (User-Agent + Sec-CH-UA + Sec-CH-UA-Mobile) is sent in full with the YAML quoting stripped.
- Full wrapper-chain verification on a dynamic build is in progress; the authoritative number will come from the next nightly.

The published device detection figure will change to reflect the heavier, client-hint-inclusive workload, making it directly comparable to the other APIs.