### PR TITLE
Fix static builds (issue #359)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,18 @@ endif
 # compiled with different data file layout options.
 ifndef STATIC_BUILD
 	MODULE_ARGS := --add-dynamic-module=$(CURDIR)/51Degrees_hash_module --add-dynamic-module=$(CURDIR)/51Degrees_ipi_module
+	# A dynamic build loads the module at runtime with load_module.
+	LOAD_MODULE := load_module $(MODULEPATH);
 else
 	ifeq ($(API),ipi)
 		MODULE_ARGS := --add-module=$(CURDIR)/51Degrees_ipi_module
 	else
 		MODULE_ARGS := --add-module=$(CURDIR)/51Degrees_hash_module
 	endif
+	# A static build links the module into the Nginx binary, so there is
+	# no module to load and a load_module directive would fail to open the
+	# non existent shared object.
+	LOAD_MODULE :=
 endif
 
 .PHONY hash:
@@ -179,6 +185,12 @@ install: configure
 	sed -i "s!%%FILE_PATH_IPI%%!$(FILEPATH_IPI)!g" build/nginx.conf
 	sed -i "s!%%TEST_GLOBALS%%!!g" build/nginx.conf
 	sed -i "s!%%TEST_GLOBALS_HTTP%%!!g" build/nginx.conf
+ifdef STATIC_BUILD
+	# The module is linked into the Nginx binary, so remove the
+	# load_module directive which would otherwise fail to open a shared
+	# object that a static build does not produce.
+	sed -i "/load_module/d" build/nginx.conf
+endif
 	echo > build/html/$(API)
 
 install-no-module: configure-no-module	
@@ -229,7 +241,7 @@ test: test-prep
 ifeq (,$(wildcard $(FULLPATH)/nginx))
 	$(error Local binary must be built first (use "make install"))
 else
-	$(eval CMD := TEST_NGINX_BINARY="$(FULLPATH)/nginx" TEST_NGINX_GLOBALS="load_module $(MODULEPATH);" TEST_NGINX_GLOBALS_HTTP="51D_file_path $(FILEPATH);" ASAN_OPTIONS=detect_odr_violation=0 LSAN_OPTIONS=suppressions=suppressions.txt prove $(FIFTYONEDEGREES_FORMATTER) -v $(TESTS) :: $(DATAFILE))
+	$(eval CMD := TEST_NGINX_BINARY="$(FULLPATH)/nginx" TEST_NGINX_GLOBALS="$(LOAD_MODULE)" TEST_NGINX_GLOBALS_HTTP="51D_file_path $(FILEPATH);" ASAN_OPTIONS=detect_odr_violation=0 LSAN_OPTIONS=suppressions=suppressions.txt prove $(FIFTYONEDEGREES_FORMATTER) -v $(TESTS) :: $(DATAFILE))
 ifdef FIFTYONEDEGREES_TEST_OUTPUT
 	$(CMD) > $(FIFTYONEDEGREES_TEST_OUTPUT)
 else

--- a/ci/options.json
+++ b/ci/options.json
@@ -23,6 +23,13 @@
   },
   {
     "Image": "ubuntu-latest",
+    "Name": "ubuntu-latest_Nginx1.29.3_MemCheck_Static",
+    "NginxVersion": "1.29.3",
+    "BuildMethod": "static",
+    "MemCheck": true
+  },
+  {
+    "Image": "ubuntu-latest",
     "Name": "ubuntu-latest_Nginx1.29.0",
     "NginxVersion": "1.29.0",
     "NginxPlusVersion": "35",

--- a/ci/run-integration-tests.ps1
+++ b/ci/run-integration-tests.ps1
@@ -21,6 +21,12 @@ try {
     sed -i "s/51Degrees-LiteV4\.1\.hash/TAC-HashV41\.hash/g" build/nginx.conf
     # Remove the documentation block
     sed -i "/\/\*\*/,/\*\//d" build/nginx.conf
+    # A static build links the module into the Nginx binary, so remove the
+    # load_module directive which would otherwise fail to open a shared
+    # object that a static build does not produce.
+    if ($BuildMethod -eq 'static') {
+        sed -i "/load_module/d" build/nginx.conf
+    }
     # Start NGINX
     ./nginx
 

--- a/ci/update-packages.ps1
+++ b/ci/update-packages.ps1
@@ -69,14 +69,13 @@ foreach ($release in $supportedReleases) {
                 RunPerformance = $True
                 PackageRequirement = $True
             })
-            # # TODO: uncomment when static build works
-            # [void]$options.Add([ordered]@{
-            #     Image = $image
-            #     Name = "$($image)_Nginx$($openSourceOf[$release])_MemCheck_Static"
-            #     NginxVersion = $openSourceOf[$release]
-            #     BuildMethod = "static"
-            #     MemCheck = $True
-            # })
+            [void]$options.Add([ordered]@{
+                Image = $image
+                Name = "$($image)_Nginx$($openSourceOf[$release])_MemCheck_Static"
+                NginxVersion = $openSourceOf[$release]
+                BuildMethod = "static"
+                MemCheck = $True
+            })
         }
     }
 }

--- a/module_conf/hash_config
+++ b/module_conf/hash_config
@@ -1,9 +1,21 @@
 ngx_addon_name=ngx_http_51D_module
 
 if test -n "$ngx_module_link"; then
-	ngx_module_type=HTTP
 	ngx_module_name=ngx_http_51D_module
 	ngx_module_srcs="$ngx_addon_dir/ngx_http_51D_module.c $ngx_addon_dir/src/*.c $ngx_addon_dir/src/hash/*.c $ngx_addon_dir/src/common-cxx/*.c"
+	# The module installs a body filter to serve the 51D_get_javascript
+	# content. A static build places plain HTTP modules before the core
+	# filters, which would leave the body filter below the write filter
+	# where it is never called, so register it as a filter type. This
+	# places it among the core body filters, just before the copy filter,
+	# so the JavaScript content is generated. A dynamic module is loaded
+	# after the core filters and already sits at the top of the chain, so
+	# it keeps the plain HTTP type.
+	if test "$ngx_module_link" = DYNAMIC; then
+		ngx_module_type=HTTP
+	else
+		ngx_module_type=HTTP_FILTER
+	fi
 
 	. auto/module
 else


### PR DESCRIPTION
Fixes [#359](https://github.com/51Degrees/device-detection-nginx/issues/359).

Static builds (`STATIC_BUILD=1`) were disabled because they failed at startup. Two separate problems:

## 1. load_module on a static build

A static build links the module into the Nginx binary, so there is no shared object, but the generated configs still carried a `load_module` directive that failed with a dlopen error. `load_module` is now omitted for static builds in the Makefile `install` and `test` targets and in `ci/run-integration-tests.ps1`. Dynamic builds (the default, and what CI uses) are unaffected.

## 2. JavaScript body filter never called in a static build

Static builds place plain `HTTP` modules before the core filter modules, so the body filter the module installs to serve `51D_get_javascript` content was ordered below the write filter where it is never called, and the content was served as a 404. The module is now registered with the `HTTP_FILTER` type for static builds, which orders it among the core body filters just before the copy filter, so the content is generated. Dynamic builds keep the plain `HTTP` type and are unchanged. The IP intelligence module has no body filter and is untouched.

## Re-enablement

The `MemCheck_Static` CI configuration is re-enabled in `ci/update-packages.ps1` and `options.json` regenerated.

## Verification

- Static build, Enterprise data file: unit tests **52/52** including all the JavaScript tests (41-48) that previously 404'd. `nginx -t` passes (no dlopen error), and the static binary serves device detection and JavaScript content.
- Dynamic build unchanged: `make test` **32/32**, `make test-examples` **35/35**. The dynamic config path in `module_conf/hash_config` is byte-identical to before.
- Static mem-check (ASAN) build and unit tests verified separately.