### PR TITLE
Keep the static memory check CI configuration disabled

### DIFF
--- a/ci/options.json
+++ b/ci/options.json
@@ -23,13 +23,6 @@
   },
   {
     "Image": "ubuntu-latest",
-    "Name": "ubuntu-latest_Nginx1.29.3_MemCheck_Static",
-    "NginxVersion": "1.29.3",
-    "BuildMethod": "static",
-    "MemCheck": true
-  },
-  {
-    "Image": "ubuntu-latest",
     "Name": "ubuntu-latest_Nginx1.29.0",
     "NginxVersion": "1.29.0",
     "NginxPlusVersion": "35",

--- a/ci/update-packages.ps1
+++ b/ci/update-packages.ps1
@@ -69,13 +69,16 @@ foreach ($release in $supportedReleases) {
                 RunPerformance = $True
                 PackageRequirement = $True
             })
-            [void]$options.Add([ordered]@{
-                Image = $image
-                Name = "$($image)_Nginx$($openSourceOf[$release])_MemCheck_Static"
-                NginxVersion = $openSourceOf[$release]
-                BuildMethod = "static"
-                MemCheck = $True
-            })
+            # The static build itself works, but the unit and example test
+            # harnesses still load the module dynamically, so this is left
+            # disabled until they are made static aware. See issue #359.
+            # [void]$options.Add([ordered]@{
+            #     Image = $image
+            #     Name = "$($image)_Nginx$($openSourceOf[$release])_MemCheck_Static"
+            #     NginxVersion = $openSourceOf[$release]
+            #     BuildMethod = "static"
+            #     MemCheck = $True
+            # })
         }
     }
 }


### PR DESCRIPTION
Follow-up to [#397](https://github.com/51Degrees/device-detection-nginx/pull/397). That change fixed the static build itself (load_module omission and filter ordering, both verified), and re-enabled the `MemCheck_Static` CI configuration. However the configuration still fails in CI because the **test harnesses are not static aware**:

- `ci/run-unit-tests.ps1` runs `make test` without `STATIC_BUILD`, so the unit tests load the module with `load_module` (which fails for a static build, no `.so`).
- `ci/run-integration-tests.ps1` runs `make test-examples` similarly, and the example `.t` files inject `load_module` unconditionally.

The reported ASAN leak is a symptom of nginx's failed-dlopen error path, not a separate issue.

This re-disables the configuration to restore a green nightly. The build and module fixes from #397 (which make static builds actually work) remain in place. Making the harnesses static aware and re-enabling the configuration is tracked as follow-up under #359.