### PR TITLE
Make the test harness static aware and re-enable the static CI config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,16 +67,29 @@ ifndef STATIC_BUILD
 	MODULE_ARGS := --add-dynamic-module=$(CURDIR)/51Degrees_hash_module --add-dynamic-module=$(CURDIR)/51Degrees_ipi_module
 	# A dynamic build loads the module at runtime with load_module.
 	LOAD_MODULE := load_module $(MODULEPATH);
+	# A dynamic build loads both modules, so all of the examples run.
+	TEST_NGINX_STATIC :=
+	EXAMPLE_TESTS := tests/examples
 else
 	ifeq ($(API),ipi)
 		MODULE_ARGS := --add-module=$(CURDIR)/51Degrees_ipi_module
+		# Only the IP intelligence example uses just the IP intelligence module.
+		EXAMPLE_TESTS := tests/examples/ipiGettingStarted.t
 	else
 		MODULE_ARGS := --add-module=$(CURDIR)/51Degrees_hash_module
+		# The device detection examples use only the device detection module.
+		# The mixed example needs both modules and so cannot run statically.
+		EXAMPLE_TESTS := tests/examples/config.t tests/examples/gettingStarted.t \
+			tests/examples/matchMetrics.t tests/examples/matchQuery.t \
+			tests/examples/responseHeader.t
 	endif
 	# A static build links the module into the Nginx binary, so there is
 	# no module to load and a load_module directive would fail to open the
 	# non existent shared object.
 	LOAD_MODULE :=
+	# Tell the example tests to omit the load_module directive. Only the
+	# examples for the single linked module are run, see EXAMPLE_TESTS.
+	TEST_NGINX_STATIC := 1
 endif
 
 .PHONY hash:
@@ -229,7 +242,7 @@ test-examples: test-prep
 ifeq (,$(wildcard $(FULLPATH)/nginx))
 	$(error Local binary must be built first (use "make install"))
 else
-	$(eval CMD := TEST_NGINX_BINARY="$(FULLPATH)/nginx" TEST_MODULE_PATH="$(FULLPATH)/build/" TEST_FILE_PATH="$(FILEPATH)" TEST_FILE_PATH_IPI="$(FILEPATH_IPI)" ASAN_OPTIONS=detect_odr_violation=0 LSAN_OPTIONS=suppressions=suppressions.txt prove $(FIFTYONEDEGREES_FORMATTER) -v tests/examples :: $(DATAFILE))
+	$(eval CMD := TEST_NGINX_BINARY="$(FULLPATH)/nginx" TEST_MODULE_PATH="$(FULLPATH)/build/" TEST_NGINX_STATIC="$(TEST_NGINX_STATIC)" TEST_FILE_PATH="$(FILEPATH)" TEST_FILE_PATH_IPI="$(FILEPATH_IPI)" ASAN_OPTIONS=detect_odr_violation=0 LSAN_OPTIONS=suppressions=suppressions.txt prove $(FIFTYONEDEGREES_FORMATTER) -v $(EXAMPLE_TESTS) :: $(DATAFILE))
 ifdef FIFTYONEDEGREES_TEST_OUTPUT
 	$(CMD) > $(FIFTYONEDEGREES_TEST_OUTPUT)
 else

--- a/ci/options.json
+++ b/ci/options.json
@@ -23,6 +23,13 @@
   },
   {
     "Image": "ubuntu-latest",
+    "Name": "ubuntu-latest_Nginx1.29.3_MemCheck_Static",
+    "NginxVersion": "1.29.3",
+    "BuildMethod": "static",
+    "MemCheck": true
+  },
+  {
+    "Image": "ubuntu-latest",
     "Name": "ubuntu-latest_Nginx1.29.0",
     "NginxVersion": "1.29.0",
     "NginxPlusVersion": "35",

--- a/ci/run-integration-tests.ps1
+++ b/ci/run-integration-tests.ps1
@@ -51,9 +51,11 @@ try {
         ./nginx -s quit
     }
 
-    # Test the examples
+    # Test the examples. A static build links a single module, so make
+    # omits load_module and runs only that module's examples.
+    $staticBuild = $BuildMethod -eq 'static' ? 'STATIC_BUILD=1' : $null
     Write-Host "Testing examples"
-    make test-examples DONT_CLEAN_TESTS=1 FIFTYONEDEGREES_DATAFILE=TAC-HashV41.hash FIFTYONEDEGREES_FORMATTER='--formatter TAP::Formatter::JUnit' FIFTYONEDEGREES_TEST_OUTPUT=$results/${Name}_Examples.xml
+    make test-examples $staticBuild DONT_CLEAN_TESTS=1 FIFTYONEDEGREES_DATAFILE=TAC-HashV41.hash FIFTYONEDEGREES_FORMATTER='--formatter TAP::Formatter::JUnit' FIFTYONEDEGREES_TEST_OUTPUT=$results/${Name}_Examples.xml
 } finally {
     Pop-Location
 }

--- a/ci/run-unit-tests.ps1
+++ b/ci/run-unit-tests.ps1
@@ -9,6 +9,11 @@ $ErrorActionPreference = "Stop"
 
 $failed = $false
 
+# A static build links the module into the Nginx binary, so the tests must
+# not try to load it with load_module. Pass STATIC_BUILD through to make so
+# the load_module directive is omitted.
+$staticBuild = $BuildMethod -eq 'static' ? 'STATIC_BUILD=1' : $null
+
 $repo = (Get-Item $PSScriptRoot/..).FullName
 Push-Location $repo
 try {
@@ -16,7 +21,7 @@ try {
     $results = New-Item -ItemType directory -Force -Path test-results/unit
 
     Write-Host "Running 51Degrees unit tests"
-    make test FIFTYONEDEGREES_DATAFILE=TAC-HashV41.hash FIFTYONEDEGREES_FORMATTER='--formatter TAP::Formatter::JUnit' FIFTYONEDEGREES_TEST_OUTPUT=$results/$Name.xml || $($failed = $true)
+    make test $staticBuild FIFTYONEDEGREES_DATAFILE=TAC-HashV41.hash FIFTYONEDEGREES_FORMATTER='--formatter TAP::Formatter::JUnit' FIFTYONEDEGREES_TEST_OUTPUT=$results/$Name.xml || $($failed = $true)
     # Output the full results file, as some bits are not reported in GitHub
     Get-Content -Raw $results/$Name.xml
 

--- a/ci/update-packages.ps1
+++ b/ci/update-packages.ps1
@@ -69,16 +69,13 @@ foreach ($release in $supportedReleases) {
                 RunPerformance = $True
                 PackageRequirement = $True
             })
-            # The static build itself works, but the unit and example test
-            # harnesses still load the module dynamically, so this is left
-            # disabled until they are made static aware. See issue #359.
-            # [void]$options.Add([ordered]@{
-            #     Image = $image
-            #     Name = "$($image)_Nginx$($openSourceOf[$release])_MemCheck_Static"
-            #     NginxVersion = $openSourceOf[$release]
-            #     BuildMethod = "static"
-            #     MemCheck = $True
-            # })
+            [void]$options.Add([ordered]@{
+                Image = $image
+                Name = "$($image)_Nginx$($openSourceOf[$release])_MemCheck_Static"
+                NginxVersion = $openSourceOf[$release]
+                BuildMethod = "static"
+                MemCheck = $True
+            })
         }
     }
 }

--- a/tests/examples/config.t
+++ b/tests/examples/config.t
@@ -42,6 +42,11 @@ $t_file =~ s/\/\*\*.+\*\//''/gmse;
 # Updated all variable place holders
 $t_file =~ s/%%DAEMON_MODE%%/'off'/gmse;
 $t_file =~ s/%%MODULE_PATH%%/$ENV{TEST_MODULE_PATH}/gmse;
+# A static build links the module into the Nginx binary, so omit the
+# load_module directive, which would fail to open a non existent shared
+# object.
+$t_file =~ s/^.*load_module.*
+//mg if $ENV{TEST_NGINX_STATIC};
 $t_file =~ s/%%FILE_PATH%%/$ENV{TEST_FILE_PATH}/gmse;
 $t->write_file_expand('nginx.conf', $t_file);
 

--- a/tests/examples/gettingStarted.t
+++ b/tests/examples/gettingStarted.t
@@ -42,6 +42,11 @@ $t_file =~ s/\/\*\*.+\*\//''/gmse;
 # Replace all variable place holders.
 $t_file =~ s/%%DAEMON_MODE%%/'off'/gmse;
 $t_file =~ s/%%MODULE_PATH%%/$ENV{TEST_MODULE_PATH}/gmse;
+# A static build links the module into the Nginx binary, so omit the
+# load_module directive, which would fail to open a non existent shared
+# object.
+$t_file =~ s/^.*load_module.*
+//mg if $ENV{TEST_NGINX_STATIC};
 $t_file =~ s/%%FILE_PATH%%/$ENV{TEST_FILE_PATH}/gmse;
 $t->write_file_expand('nginx.conf', $t_file);
 

--- a/tests/examples/ipiGettingStarted.t
+++ b/tests/examples/ipiGettingStarted.t
@@ -72,6 +72,11 @@ $t_file =~ s/\/\*\*.+\*\//''/gmse;
 # Replace all variable place holders.
 $t_file =~ s/%%DAEMON_MODE%%/'off'/gmse;
 $t_file =~ s/%%MODULE_PATH%%/$ENV{TEST_MODULE_PATH}/gmse;
+# A static build links the module into the Nginx binary, so omit the
+# load_module directive, which would fail to open a non existent shared
+# object.
+$t_file =~ s/^.*load_module.*
+//mg if $ENV{TEST_NGINX_STATIC};
 $t_file =~ s/%%FILE_PATH_IPI%%/$ipiFilePath/gmse;
 $t->write_file_expand('nginx.conf', $t_file);
 

--- a/tests/examples/matchMetrics.t
+++ b/tests/examples/matchMetrics.t
@@ -42,6 +42,11 @@ $t_file =~ s/\/\*\*.+\*\//''/gmse;
 # Replace variable place holders
 $t_file =~ s/%%DAEMON_MODE%%/'off'/gmse;
 $t_file =~ s/%%MODULE_PATH%%/$ENV{TEST_MODULE_PATH}/gmse;
+# A static build links the module into the Nginx binary, so omit the
+# load_module directive, which would fail to open a non existent shared
+# object.
+$t_file =~ s/^.*load_module.*
+//mg if $ENV{TEST_NGINX_STATIC};
 $t_file =~ s/%%FILE_PATH%%/$ENV{TEST_FILE_PATH}/gmse;
 $t->write_file_expand('nginx.conf', $t_file);
 

--- a/tests/examples/matchQuery.t
+++ b/tests/examples/matchQuery.t
@@ -42,6 +42,11 @@ $t_file =~ s/\/\*\*.+\*\//''/gmse;
 # Remove all variable place holders
 $t_file =~ s/%%DAEMON_MODE%%/'off'/gmse;
 $t_file =~ s/%%MODULE_PATH%%/$ENV{TEST_MODULE_PATH}/gmse;
+# A static build links the module into the Nginx binary, so omit the
+# load_module directive, which would fail to open a non existent shared
+# object.
+$t_file =~ s/^.*load_module.*
+//mg if $ENV{TEST_NGINX_STATIC};
 $t_file =~ s/%%FILE_PATH%%/$ENV{TEST_FILE_PATH}/gmse;
 $t->write_file_expand('nginx.conf', $t_file);
 

--- a/tests/examples/mixedGettingStarted.t
+++ b/tests/examples/mixedGettingStarted.t
@@ -77,6 +77,11 @@ $t_file =~ s/\/\*\*.+\*\//''/gmse;
 # Replace all variable place holders.
 $t_file =~ s/%%DAEMON_MODE%%/'off'/gmse;
 $t_file =~ s/%%MODULE_PATH%%/$ENV{TEST_MODULE_PATH}/gmse;
+# A static build links the module into the Nginx binary, so omit the
+# load_module directive, which would fail to open a non existent shared
+# object.
+$t_file =~ s/^.*load_module.*
+//mg if $ENV{TEST_NGINX_STATIC};
 $t_file =~ s/%%FILE_PATH%%/$hashFilePath/gmse;
 $t_file =~ s/%%FILE_PATH_IPI%%/$ipiFilePath/gmse;
 $t->write_file_expand('nginx.conf', $t_file);

--- a/tests/examples/responseHeader.t
+++ b/tests/examples/responseHeader.t
@@ -52,6 +52,11 @@ $t_file =~ s/\/\*\*.+\*\//''/gmse;
 # Replace all variable place holder
 $t_file =~ s/%%DAEMON_MODE%%/'off'/gmse;
 $t_file =~ s/%%MODULE_PATH%%/$ENV{TEST_MODULE_PATH}/gmse;
+# A static build links the module into the Nginx binary, so omit the
+# load_module directive, which would fail to open a non existent shared
+# object.
+$t_file =~ s/^.*load_module.*
+//mg if $ENV{TEST_NGINX_STATIC};
 $t_file =~ s/%%FILE_PATH%%/$ENV{TEST_FILE_PATH}/gmse;
 $t->write_file_expand('nginx.conf', $t_file);
 


### PR DESCRIPTION
Follow-up to [#397](https://github.com/51Degrees/device-detection-nginx/pull/397) and [#399](https://github.com/51Degrees/device-detection-nginx/pull/399), completing the static build work for [#359](https://github.com/51Degrees/device-detection-nginx/issues/359).

#397 fixed the static build itself (load_module omission, filter ordering). Re-enabling the `MemCheck_Static` CI config then failed because the **test harnesses still loaded the module dynamically** — so it was reverted in #399. This makes the harnesses static aware and re-enables the config.

## Changes

- `ci/run-unit-tests.ps1` and `ci/run-integration-tests.ps1` pass `STATIC_BUILD` through to `make` for static builds, so the Makefile omits `load_module` (the unit tests and the `LOAD_MODULE` global were already static-aware from #397).
- The example `.t` tests strip the `load_module` directive when `TEST_NGINX_STATIC` is set, as the module is linked into the binary.
- A static build links a single module, so `EXAMPLE_TESTS` limits the example run to that module's examples. The `mixed` example needs both modules and cannot run statically; `ipi`/`mixed` are excluded for a static hash build.
- The `MemCheck_Static` config is re-enabled and `options.json` regenerated.

## Verification (the full CI harness commands, run locally on a static mem-check build)

- Static `make test STATIC_BUILD=1`: **52/52** (incl. JavaScript, under ASAN).
- Static `make test-examples STATIC_BUILD=1`: runs the **5 device detection examples** (Files=5, 20 tests), no `load_module`, all pass — ipi/mixed correctly excluded.
- Dynamic `make test` **32/32**, `make test-examples` **all 7** (35) — no regression.

The previous re-enable was merged without running the full harness path; this time both the static and dynamic harness commands were verified locally first. The nightly will confirm on nginx 1.29.3.